### PR TITLE
Fixing Issue 70. WIP

### DIFF
--- a/packages/clusview/__init__.py
+++ b/packages/clusview/__init__.py
@@ -1,0 +1,3 @@
+"""
+No idea what this is :(
+"""

--- a/packages/clusview/__init__.py
+++ b/packages/clusview/__init__.py
@@ -1,3 +1,4 @@
 """
-No idea what this is :(
+Clusview is a BERTopic based tool that aims to optimize and visualize document clustering
+using configurable cluster metering, making cluster viewing more human-readable.
 """

--- a/packages/clusview/loaders/documents/__init__.py
+++ b/packages/clusview/loaders/documents/__init__.py
@@ -1,0 +1,3 @@
+"""
+Functions for the base document loaders
+"""

--- a/packages/clusview/loaders/documents/__init__.py
+++ b/packages/clusview/loaders/documents/__init__.py
@@ -1,3 +1,3 @@
 """
-Functions for the base document loaders
+Functions for loading document.
 """

--- a/packages/clusview/metrics/__init__.py
+++ b/packages/clusview/metrics/__init__.py
@@ -1,3 +1,3 @@
 """
-Functions for collecting metrics on clusters such as average cluster size, count etc.
+Topic modelling performance metrics.
 """

--- a/packages/clusview/metrics/__init__.py
+++ b/packages/clusview/metrics/__init__.py
@@ -1,3 +1,3 @@
 """
-Topic modelling performance metrics.
+Functions for collecting metrics on clusters such as average cluster size, count etc.
 """

--- a/packages/clusview/pipelines/__init__.py
+++ b/packages/clusview/pipelines/__init__.py
@@ -1,3 +1,3 @@
 """
-Pipeline for chaining functionalities and components.
+Pipelines for chaining functionalities and components.
 """

--- a/packages/clusview/pipelines/__init__.py
+++ b/packages/clusview/pipelines/__init__.py
@@ -1,0 +1,3 @@
+"""
+Functions for pipelines for metric mapping
+"""

--- a/packages/clusview/pipelines/__init__.py
+++ b/packages/clusview/pipelines/__init__.py
@@ -1,3 +1,3 @@
 """
-Functions for pipelines for metric mapping
+Pipeline for chaining functionalities and components.
 """

--- a/packages/clusview/samplers/__init__.py
+++ b/packages/clusview/samplers/__init__.py
@@ -1,0 +1,3 @@
+"""
+Parameters?
+"""

--- a/packages/clusview/samplers/__init__.py
+++ b/packages/clusview/samplers/__init__.py
@@ -1,3 +1,3 @@
 """
-Parameters?
+Generation of ranges for sampler iteration.
 """

--- a/packages/clusview/samplers/clusters/__init__.py
+++ b/packages/clusview/samplers/clusters/__init__.py
@@ -1,3 +1,3 @@
 """
-Functions for clustering algorithms such as HDBSCAN
+Functions for clustering algorithms.
 """

--- a/packages/clusview/samplers/clusters/__init__.py
+++ b/packages/clusview/samplers/clusters/__init__.py
@@ -1,0 +1,3 @@
+"""
+Functions for clustering algorithms such as HDBSCAN
+"""

--- a/packages/clusview/samplers/clusters/__init__.py
+++ b/packages/clusview/samplers/clusters/__init__.py
@@ -1,3 +1,3 @@
 """
-Functions for clustering algorithms.
+Samplers for clustering algorithms
 """

--- a/packages/clusview/samplers/parameters/__init__.py
+++ b/packages/clusview/samplers/parameters/__init__.py
@@ -1,0 +1,3 @@
+"""
+Functions for parameter sampler.
+"""


### PR DESCRIPTION
Tried my hand at solving issue 70.  Couple of things I wanted to ask:

- When I hover over submodules for the packages (For example the `clusters` submodule under the `samplers` package), the descriptions don't show up despite adding them to their respective `__init__.py` files.
- Would it be possible to get a brief description of some of the packages? 